### PR TITLE
Fixed bv09_side_scroll tiles-not-loading issue

### DIFF
--- a/bevy_demos/examples/bv09_side_scroll.rs
+++ b/bevy_demos/examples/bv09_side_scroll.rs
@@ -116,7 +116,7 @@ fn setup(
     let mut t = Vec3::new(
         -WIN_W / 2. + (TILE_SIZE as f32) / 2.,
         -WIN_H / 2. + (TILE_SIZE as f32) / 2.,
-        0.,
+        1.,
     );
     while i * TILE_SIZE < (LEVEL_LEN as u32) {
         info!("Spawning brick at {:?}", t);


### PR DESCRIPTION
Hello! I don't know if someone already solved it, but I was rewatching the lectures to study for the midterm and came across the bv09 issue that I forgot about. Anyway, I was bored so I fiddled around with it a bit and I got it working! Very simple issue, I believe the background was loading in after the tiles, and since they're both spawning at z axis 0, the background was loading in on top of the tiles. Changing the z axis to 1 for the tiles and/or changing the background to -1 fixed the issue. 